### PR TITLE
Use correct value for app queue

### DIFF
--- a/main.go
+++ b/main.go
@@ -156,7 +156,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(e.appCount, prometheus.GaugeValue, parseFloat(info.AppCount))
 
 	for _, sg := range info.SuperGroups {
-		ch <- prometheus.MustNewConstMetric(e.appQueue, prometheus.GaugeValue, parseFloat(sg.RequestsInQueue), sg.Name)
+		ch <- prometheus.MustNewConstMetric(e.appQueue, prometheus.GaugeValue, parseFloat(sg.Group.GetWaitListSize), sg.Name)
 		ch <- prometheus.MustNewConstMetric(e.appProcsSpawning, prometheus.GaugeValue, parseFloat(sg.Group.ProcessesSpawning), sg.Name)
 
 		// Update process identifiers map.


### PR DESCRIPTION
There are two levels of `get_wait_list_size`, one on the supergroup level and one on the group level. 

Through investigation and some quick load testing it seems that the correct value to use for the app request queue size is the deepest level of the `get_wait_list_size` i.e. on the group level.

My assumption here is that the supergroup's `get_wait_list_size` is more similar to the top level queue, which rarely fills up.