### PR TITLE
Change user/group to nobody:nogroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.0
+
+* Run as user `nobody` and group `nogroup` instead of `root`.
+
 ## 0.5.1
 
 ### Bug Fixes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @itskingori @tsu-shiuan @zacblazic
+* @Intellection/devops

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,5 +47,7 @@ RUN promu build && \
 RUN apk del $BUILD_PACKAGES && \
     rm -rf /var/cache/apk/*
 
+USER nobody:nogroup
+
 ENTRYPOINT ["tini", "--", "passenger-exporter"]
 CMD ["/bin/sh"]


### PR DESCRIPTION
Because we don't need to run as `root`. To note the UID of `nobody` is `65534` and the GID of `nogroup` is `65534`. The `ruby:2.4.3-alpine3.7` image already has a `nobody` user and a `nogroup` group. See below:

```console
$ docker run -it ruby:2.4.3-alpine3.7 /bin/sh
/ # cat /etc/passwd | grep 'nobody'
nobody:x:65534:65534:nobody:/:/sbin/nologin
/ # cat /etc/group | grep 'nogroup'
nogroup:x:65533:
```