### PR TITLE
Fix docker image build

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -1,4 +1,4 @@
-go: 1.9.2
+go: 1.9.4
 repository:
     path: github.com/Intellection/passenger-exporter
 build:

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,4 +1,5 @@
-go: 1.9.4
+go:
+    version: 1.9.4
 repository:
     path: github.com/Intellection/passenger-exporter
 build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.6.0
 
 * Run as user `nobody` and group `nogroup` instead of `root`.
+* Update Go to `v1.9.4`.
 
 ## 0.5.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.4.3-alpine3.7
 
-ARG GOLANG_VERSION="1.9.2-r1"
+ARG GOLANG_VERSION="1.9.4-r0"
 ARG BUILD_DEPS="go=$GOLANG_VERSION ruby-dev linux-headers curl curl-dev pcre-dev libexecinfo-dev@edge-main"
 ARG RUNTIME_DEPS="tini build-base pcre git libexecinfo@edge-main"
 


### PR DESCRIPTION
Build now works:

```console
$ docker build -t zappi/passenger-exporter:latest .
Sending build context to Docker daemon  10.74MB
Step 1/19 : FROM ruby:2.4.3-alpine3.7
 ---> fd96a4a8fa54
Step 2/19 : ARG GOLANG_VERSION="1.9.4-r0"
 ---> Using cache
 ---> a378c8bb4721
Step 3/19 : ARG BUILD_DEPS="go=$GOLANG_VERSION ruby-dev linux-headers curl curl-dev pcre-dev libexecinfo-dev@edge-main"
 ---> Using cache
 ---> cb2483b8637c
Step 4/19 : ARG RUNTIME_DEPS="tini build-base pcre git libexecinfo@edge-main"
 ---> Using cache
 ---> 3c59a8db0851
Step 5/19 : RUN echo '@edge-main http://dl-cdn.alpinelinux.org/alpine/edge/main/' >> /etc/apk/repositories &&     apk update &&     apk upgrade &&     apk add $BUILD_DEPS &&     apk add $RUNTIME_DEPS &&     mkdir -p /opt
 ---> Using cache
 ---> 0007e4a4ef96
Step 6/19 : ENV PASSENGER_VERSION="5.1.12"     PATH="/opt/passenger/bin:$PATH"
 ---> Using cache
 ---> d21139a45e81
Step 7/19 : RUN curl -L "https://s3.amazonaws.com/phusion-passenger/releases/passenger-$PASSENGER_VERSION.tar.gz" | tar -xzf - -C /opt &&     mv /opt/passenger-$PASSENGER_VERSION /opt/passenger &&     passenger-config validate-install --auto &&     export EXTRA_PRE_CFLAGS='-O' EXTRA_PRE_CXXFLAGS='-O' EXTRA_LDFLAGS='-lexecinfo' &&     passenger-config compile-agent --optimize &&     passenger-config install-standalone-runtime &&     passenger-config build-native-support
 ---> Using cache
 ---> 8b3f17558d9f
Step 8/19 : ENV GOROOT="/usr/lib/go"     GOPATH="/go"
 ---> Using cache
 ---> 3bde62319093
Step 9/19 : ENV PATH="$GOPATH/bin:$GOROOT/bin:$PATH"
 ---> Using cache
 ---> 7668ba6c7a85
Step 10/19 : RUN go get github.com/prometheus/promu
 ---> Using cache
 ---> d0fb977d294b
Step 11/19 : ARG SOURCE_PATH="/go/src/github.com/Intellection/passenger-exporter"
 ---> Using cache
 ---> e8fdbd5e0255
Step 12/19 : RUN mkdir -p ${SOURCE_PATH}
 ---> Using cache
 ---> 70fa958ee103
Step 13/19 : ADD . ${SOURCE_PATH}/
 ---> 8a7af617e1f2
Step 14/19 : WORKDIR ${SOURCE_PATH}
 ---> Running in fe56984bb7b9
Removing intermediate container fe56984bb7b9
 ---> c1346b3c0dd5
Step 15/19 : RUN promu build &&     mv ${SOURCE_PATH}/passenger-exporter /usr/local/bin/passenger-exporter &&     rm -rf ${SOURCE_PATH}/*
 ---> Running in 57dde1d644d9
 >   passenger-exporter
Removing intermediate container 57dde1d644d9
 ---> 29778a0987c0
Step 16/19 : RUN apk del $BUILD_PACKAGES &&     rm -rf /var/cache/apk/*
 ---> Running in b977a82ae2a7
OK: 418 MiB in 69 packages
Removing intermediate container b977a82ae2a7
 ---> a4c4a93f0a64
Step 17/19 : USER nobody:nogroup
 ---> Running in bbde07f20bc6
Removing intermediate container bbde07f20bc6
 ---> eeb37e5a48da
Step 18/19 : ENTRYPOINT ["tini", "--", "passenger-exporter"]
 ---> Running in c0c4e72a5e21
Removing intermediate container c0c4e72a5e21
 ---> c973a514d585
Step 19/19 : CMD ["/bin/sh"]
 ---> Running in 2b7baa5126d6
Removing intermediate container 2b7baa5126d6
 ---> 29d15e083116
Successfully built 29d15e083116
Successfully tagged zappi/passenger-exporter:latest
```

Closes https://github.com/Intellection/passenger-exporter/issues/10.